### PR TITLE
Adding an custom Input control

### DIFF
--- a/lch-configuration/ComponentOptions/InputOptions.cs
+++ b/lch-configuration/ComponentOptions/InputOptions.cs
@@ -1,0 +1,11 @@
+﻿namespace lch_configuration.ComponentOptions
+{
+  public class InputOptions : IComponentOptions
+  {
+    public string Tooltip { get; set; } = "Input";
+    public string? Icon { get; set; }
+    public string CommandString { get; set; } = "cmd.exe";
+    public string? CommandOptions { get; set; }
+    public int MinWidth { get; set; } = 100;
+  }
+}

--- a/lch-configuration/Configuration/ComponentFactory.cs
+++ b/lch-configuration/Configuration/ComponentFactory.cs
@@ -6,14 +6,15 @@ namespace lch_configuration.Configuration
   {
     static readonly Dictionary<string, IComponentOptions?>  optionsByComponentName = new()
       {
-        {"bluetooth", null},
-        {"network", null},
-        {"process", null},
-        {"processes", null},
-        {"volume", new SoundOptions()},
-        {"sound", new SoundOptions()},
-        {"shortcuts" , new ShortcutOptions()},
-        {"spotify", null},
+        { "input", new InputOptions()},
+        { "bluetooth", null},
+        { "network", null},
+        { "process", null},
+        { "processes", null},
+        { "volume", new SoundOptions()},
+        { "sound", new SoundOptions()},
+        { "shortcuts" , new ShortcutOptions()},
+        { "spotify", null},
         { "time", new TimeOptions()},
         { "date", new TimeOptions()},
         { "weather", new WeatherOptions()},

--- a/lch-taskbar-wpf/TaskbarComponents/InputControl.xaml
+++ b/lch-taskbar-wpf/TaskbarComponents/InputControl.xaml
@@ -1,0 +1,11 @@
+﻿<StackPanel x:Class="lch_taskbar_wpf.TaskbarComponents.InputControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:lch_taskbar_wpf.TaskbarComponents"
+             mc:Ignorable="d" 
+             HorizontalAlignment="Stretch"
+             MinWidth="120"
+             d:DesignHeight="450" d:DesignWidth="800">
+</StackPanel>

--- a/lch-taskbar-wpf/TaskbarComponents/InputControl.xaml.cs
+++ b/lch-taskbar-wpf/TaskbarComponents/InputControl.xaml.cs
@@ -1,0 +1,63 @@
+﻿using lch_configuration.ComponentOptions;
+using lch_taskbar.TaskbarComponents;
+using lch_taskbar_wpf.Utils;
+using System.Windows.Controls;
+
+namespace lch_taskbar_wpf.TaskbarComponents
+{
+  public partial class InputControl : StackPanel
+  {
+    InputOptions inputOptions = new();
+    public InputControl(IComponentOptions? componentOptions)
+    {
+      if (componentOptions != null)
+        inputOptions = (InputOptions)componentOptions;
+
+      InitializeComponent();
+      Orientation = ControlsUtils.GetOrientationBasedOnConfig();
+      SetupControlBasedOnOptions();
+    }
+
+    private void SetupControlBasedOnOptions()
+    {
+      if (inputOptions.Icon != null)
+      {
+        var icon = ControlsUtils.GetImageFromImagePath(inputOptions.Icon, inputOptions.Tooltip);
+        icon.Margin = new System.Windows.Thickness(0, 3, 3, 3);
+        Children.Add(icon);
+      }
+
+      var textBox = new TextBox()
+      {
+        HorizontalAlignment = System.Windows.HorizontalAlignment.Stretch,
+        VerticalAlignment = System.Windows.VerticalAlignment.Center,
+        MinWidth = inputOptions.MinWidth,
+        Margin = new System.Windows.Thickness(0, 3, 0, 3),
+      };
+      textBox.KeyDown += InputTextBox_KeyDown;
+      Children.Add(textBox);
+    }
+
+    private string PrepareCommandOptions(string input)
+    {
+      if (inputOptions.CommandOptions != null && 
+          inputOptions.CommandOptions.Contains("{0}"))
+        return string.Format(inputOptions.CommandOptions, input);
+      
+      return inputOptions.CommandOptions + " " + input;
+    }
+
+    private void InputTextBox_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+    {
+      if (e.Key == System.Windows.Input.Key.Enter)
+      {
+        var textBox = (TextBox)sender;
+        var newProcess = new System.Diagnostics.Process();
+        newProcess.StartInfo.FileName = inputOptions.CommandString;
+        newProcess.StartInfo.Arguments = PrepareCommandOptions(textBox.Text);
+        newProcess.StartInfo.UseShellExecute = true;
+        newProcess.Start();
+      }
+    }
+  }
+}

--- a/lch-taskbar-wpf/TaskbarExtensions/LCHTaskbar-Components.cs
+++ b/lch-taskbar-wpf/TaskbarExtensions/LCHTaskbar-Components.cs
@@ -1,6 +1,7 @@
 ﻿using lch_configuration.ComponentOptions;
 using lch_configuration.Configuration;
 using lch_taskbar.TaskbarComponents;
+using lch_taskbar_wpf.TaskbarComponents;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -61,6 +62,7 @@ namespace lch_taskbar
       // Modify this snippet from lch-taskbar\TaskbarComponents\ComponentsDictionary.cs:
       return name?.ToLower() switch
       {
+        "input" => new InputControl(options),
         "bluetooth" => new BluetoothControl(),
         "network" => new NetworkControl(),
         "process" or "processes" => new ProcessControl(),

--- a/lch-taskbar-wpf/Utils/ControlsUtils.cs
+++ b/lch-taskbar-wpf/Utils/ControlsUtils.cs
@@ -1,10 +1,16 @@
-﻿using lch_configuration.Configuration;
+﻿using lch_configuration.ComponentOptions;
+using lch_configuration.Configuration;
+using lch_taskbar.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection.Metadata;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Interop;
+using System.Windows.Media.Imaging;
 
 namespace lch_taskbar_wpf.Utils
 {
@@ -19,6 +25,17 @@ namespace lch_taskbar_wpf.Utils
         TaskbarPosition.Top    => Orientation.Horizontal,
         TaskbarPosition.Bottom => Orientation.Horizontal,
         _ => Orientation.Horizontal
+      };
+    }
+
+    public static Image GetImageFromImagePath(string Path, string ToolTip)
+    {
+      return new Image()
+      {
+        MaxWidth = 25,
+        MaxHeight = 25,
+        ToolTip = ToolTip,
+        Source = new BitmapImage(new Uri(Path)),
       };
     }
   }

--- a/lch-taskbar-wpf/lch-taskbar-wpf.csproj.user
+++ b/lch-taskbar-wpf/lch-taskbar-wpf.csproj.user
@@ -8,6 +8,9 @@
     <Compile Update="TaskbarComponents\BluetoothControl.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Update="TaskbarComponents\InputControl.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Update="TaskbarComponents\NetworkControl.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -62,6 +65,9 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Update="TaskbarComponents\BluetoothControl.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="TaskbarComponents\InputControl.xaml">
       <SubType>Designer</SubType>
     </Page>
     <Page Update="TaskbarComponents\NetworkControl.xaml">


### PR DESCRIPTION
This new control allows the user to specify a command in the settings, and having the input type in the taskbar to be injected in that command.

Useful if you want run a command frequently with different input (for example, a search on duckduckgo).